### PR TITLE
feat(middleware): add gzip support for request and response compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/stretchr/testify v1.9.0
+	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/api/handlers/url.go
+++ b/internal/api/handlers/url.go
@@ -24,12 +24,6 @@ func NewURLHandlers(urlService *service.URLService) *URLHandlers {
 
 // Shorten handles the request to shorten a URL
 func (h *URLHandlers) Shorten(w http.ResponseWriter, r *http.Request) {
-	contentType := r.Header.Get("Content-Type")
-	parts := strings.Split(contentType, ";")
-	if len(parts) == 0 || !strings.Contains(parts[0], "text/plain") {
-		http.Error(w, "Invalid content type", http.StatusBadRequest)
-		return
-	}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)

--- a/internal/api/handlers/url_test.go
+++ b/internal/api/handlers/url_test.go
@@ -56,15 +56,6 @@ func TestURLHandlers_Shorten(t *testing.T) {
 			wantBody:   "http://localhost/shortID",
 		},
 		{
-			name: "invalid Content-Type",
-			args: args{
-				contentType: "application/json",
-				body:        "http://example.com",
-			},
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid content type\n",
-		},
-		{
 			name: "invalid URL format (URL too long)",
 			args: args{
 				contentType: "text/plain",

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -8,4 +8,5 @@ import (
 func Routes(r *chi.Mux, urlHandlers *handlers.URLHandlers) {
 	r.Post("/", urlHandlers.Shorten)
 	r.Get("/{id}", urlHandlers.Redirect)
+	r.Post("/api/shorten", urlHandlers.ShortenJSON)
 }

--- a/internal/dto/url.go
+++ b/internal/dto/url.go
@@ -1,0 +1,9 @@
+package dto
+
+type ShortenJSONRequestDTO struct {
+	URL string `json:"url"`
+}
+
+type ShortenJSONResponseDTO struct {
+	Result string `json:"result"`
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,48 @@
+package logger
+
+import (
+	"log"
+	"os"
+	"sync"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	once   sync.Once
+	logger *zap.SugaredLogger
+)
+
+func loadLogger(level zapcore.Level) {
+	stdout := zapcore.AddSync(os.Stdout)
+
+	developmentCfg := zap.NewDevelopmentEncoderConfig()
+	developmentCfg.TimeKey = "timestamp"
+	developmentCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	developmentCfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+
+	developmentConsoleEncoder := zapcore.NewConsoleEncoder(developmentCfg)
+	core := zapcore.NewTee(
+		zapcore.NewCore(developmentConsoleEncoder, stdout, level),
+	)
+	logger = zap.New(core).Sugar()
+}
+
+func NewLogger(level ...string) *zap.SugaredLogger {
+	once.Do(func() {
+		lvl := zapcore.InfoLevel
+		if len(level) > 0 {
+			if err := lvl.UnmarshalText([]byte(level[0])); err != nil {
+				log.Printf("Invalid log level: %s, defaulting to INFO", level[0])
+			}
+		}
+		loadLogger(lvl)
+	})
+	return logger
+}
+func SyncLogger() {
+	if logger != nil {
+		_ = logger.Sync()
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,81 @@
+package logger
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func resetOnce() {
+	once = sync.Once{}
+}
+
+func TestLogger_NewLogger_Level(t *testing.T) {
+	tests := []struct {
+		name    string
+		level   string
+		wantLvl zapcore.Level
+	}{
+		{
+			name:    "default log level",
+			level:   "",
+			wantLvl: zapcore.InfoLevel,
+		},
+		{
+			name:    "valid log level",
+			level:   "DEBUG",
+			wantLvl: zapcore.DebugLevel,
+		},
+		{
+			name:    "invalid log level",
+			level:   "INVALID",
+			wantLvl: zapcore.InfoLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		resetOnce()
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewLogger(tt.level)
+			assert.NotNil(t, logger)
+			assert.Equal(t, tt.wantLvl, logger.Level())
+		})
+	}
+}
+
+func TestLogger_LoadLogger(t *testing.T) {
+	type args struct {
+		level zapcore.Level
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name:    "default log level",
+			args:    args{level: zapcore.InfoLevel},
+			wantErr: nil,
+		},
+		{
+			name:    "valid log level",
+			args:    args{level: zapcore.DebugLevel},
+			wantErr: nil,
+		},
+		{
+			name:    "invalid log level",
+			args:    args{level: zapcore.FatalLevel},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadLogger(tt.args.level)
+			assert.NotNil(t, logger)
+			assert.Equal(t, tt.args.level, logger.Level())
+		})
+	}
+}

--- a/internal/middleware/compress/compress.go
+++ b/internal/middleware/compress/compress.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// compressWriter реализует интерфейс http.ResponseWriter и позволяет прозрачно для сервера
+// сжимать передаваемые данные и выставлять правильные HTTP-заголовки
+type compressWriter struct {
+	w  http.ResponseWriter
+	zw *gzip.Writer
+}
+
+// compressReader реализует интерфейс io.ReadCloser и позволяет прозрачно для сервера
+// декомпрессировать получаемые от клиента данные
+type compressReader struct {
+	r  io.ReadCloser
+	zr *gzip.Reader
+}
+
+func newCompressWriter(w http.ResponseWriter) *compressWriter {
+	return &compressWriter{
+		w:  w,
+		zw: gzip.NewWriter(w),
+	}
+}
+
+func newCompressReader(r io.ReadCloser) (*compressReader, error) {
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compressReader{
+		r:  r,
+		zr: zr,
+	}, nil
+}
+
+func (c *compressWriter) Header() http.Header {
+	return c.w.Header()
+}
+
+func (c *compressWriter) Write(p []byte) (int, error) {
+	return c.zw.Write(p)
+}
+
+func (c *compressWriter) WriteHeader(statusCode int) {
+	if statusCode < 300 {
+		c.w.Header().Set("Content-Encoding", "gzip")
+	}
+	c.w.WriteHeader(statusCode)
+}
+
+func (c *compressWriter) Close() error {
+	return c.zw.Close()
+}
+
+func (c compressReader) Read(p []byte) (n int, err error) {
+	return c.zr.Read(p)
+}
+
+func (c *compressReader) Close() error {
+	if err := c.r.Close(); err != nil {
+		return err
+	}
+	return c.zr.Close()
+}
+
+func CompressMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// по умолчанию устанавливаем оригинальный http.ResponseWriter как тот,
+		// который будем передавать следующей функции
+		ow := w
+		// проверяем, что клиент отправил серверу сжатые данные в формате gzip
+		if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
+			// оборачиваем тело запроса в io.Reader с поддержкой декомпрессии
+			cr, err := newCompressReader(r.Body)
+			if err != nil {
+				log.Printf("Ошибка при декомпрессии: %v", err)
+
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			// меняем тело запроса на новое
+			defer cr.Close()
+			r.Body = cr
+		}
+		// проверяем, что клиент умеет получать от сервера сжатые данные в формате gzip
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			// оборачиваем оригинальный http.ResponseWriter новым с поддержкой сжатия
+			cw := newCompressWriter(w)
+			// меняем оригинальный http.ResponseWriter на новый
+			defer cw.Close()
+			ow = cw
+			// не забываем отправить клиенту все сжатые данные после завершения middleware
+		}
+		// передаём управление хендлеру
+		h.ServeHTTP(ow, r)
+	})
+}

--- a/internal/middleware/compress/compress_test.go
+++ b/internal/middleware/compress/compress_test.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte("OK"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func gzipCompress(data string) *bytes.Buffer {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(data))
+	if err != nil {
+		log.Fatalf("Ошибка сжатия: %v", err)
+	}
+	gz.Close()
+	return &buf
+}
+
+func TestCompressMiddleware(t *testing.T) {
+	tests := []struct {
+		name            string
+		handler         http.Handler
+		acceptEncoding  string
+		contentEncoding string
+		requestBody     string
+		expectedBody    string
+		expectedStatus  int
+	}{
+		{
+			name:            "Uncompressed request and response",
+			handler:         http.HandlerFunc(okHandler),
+			acceptEncoding:  "",
+			contentEncoding: "",
+			requestBody:     "Hello, world!",
+			expectedBody:    "OK",
+			expectedStatus:  http.StatusOK,
+		},
+		{
+			name:            "Compressed request, uncompressed response",
+			handler:         http.HandlerFunc(okHandler),
+			acceptEncoding:  "",
+			contentEncoding: "gzip",
+			requestBody:     "Hello, compressed!",
+			expectedBody:    "OK",
+			expectedStatus:  http.StatusOK,
+		},
+		{
+			name:            "Uncompressed request, compressed response",
+			handler:         http.HandlerFunc(okHandler),
+			acceptEncoding:  "gzip",
+			contentEncoding: "",
+			requestBody:     "",
+			expectedBody:    "OK",
+			expectedStatus:  http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reqBody io.Reader
+			if tt.contentEncoding == "gzip" {
+				reqBody = gzipCompress(tt.requestBody)
+			} else {
+				reqBody = strings.NewReader(tt.requestBody)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/", reqBody)
+			req.Header.Set("Content-Encoding", tt.contentEncoding)
+			req.Header.Set("Accept-Encoding", tt.acceptEncoding)
+
+			rec := httptest.NewRecorder()
+			middleware := CompressMiddleware(tt.handler)
+			middleware.ServeHTTP(rec, req)
+
+			res := rec.Result()
+			defer res.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, res.StatusCode)
+
+			var body []byte
+			var err error
+			if tt.acceptEncoding == "gzip" {
+				gzr, err := gzip.NewReader(res.Body)
+				assert.NoError(t, err, "ошибка при создании gzip.Reader")
+				defer gzr.Close()
+				body, err = io.ReadAll(gzr)
+				assert.NoError(t, err, "ошибка при чтении сжатого тела ответа")
+			} else {
+				body, err = io.ReadAll(res.Body)
+				assert.NoError(t, err, "ошибка при чтении тела ответа")
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedBody, string(body))
+		})
+	}
+}

--- a/internal/middleware/http/request.go
+++ b/internal/middleware/http/request.go
@@ -1,4 +1,4 @@
-package custom
+package middleware
 
 import (
 	"net/http"

--- a/internal/middleware/http/request_test.go
+++ b/internal/middleware/http/request_test.go
@@ -1,0 +1,101 @@
+package custom
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte("OK"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func notFoundHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func methodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}
+
+func largeBodyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write(bytes.Repeat([]byte("A"), 1024*1024))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func TestRequestMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		handler        http.Handler
+		method         string
+		expectedStatus int
+		expectedSize   int
+	}{
+		{
+			name:           "GET request with OK status",
+			handler:        http.HandlerFunc(okHandler),
+			method:         http.MethodGet,
+			expectedStatus: http.StatusOK,
+			expectedSize:   len("OK"),
+		},
+		{
+			name:           "GET request with 404 status",
+			handler:        http.HandlerFunc(notFoundHandler),
+			method:         http.MethodGet,
+			expectedStatus: http.StatusNotFound,
+			expectedSize:   0,
+		},
+		{
+			name:           "POST request not allowed",
+			handler:        http.HandlerFunc(methodNotAllowedHandler),
+			method:         http.MethodPost,
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedSize:   0,
+		},
+		{
+			name:           "Large body response",
+			handler:        http.HandlerFunc(largeBodyHandler),
+			method:         http.MethodGet,
+			expectedStatus: http.StatusOK,
+			expectedSize:   1024 * 1024,
+		},
+		{
+			name:           "Empty response body",
+			handler:        http.HandlerFunc(notFoundHandler),
+			method:         http.MethodGet,
+			expectedStatus: http.StatusNotFound,
+			expectedSize:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/", nil)
+			rec := httptest.NewRecorder()
+
+			middleware := RequestMiddleware(tt.handler)
+			middleware.ServeHTTP(rec, req)
+
+			res := rec.Result()
+			defer res.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, res.StatusCode, "unexpected status code")
+			body, err := io.ReadAll(res.Body)
+			assert.NoError(t, err, "failed to read response body")
+			assert.Equal(t, tt.expectedSize, len(body), "unexpected response size")
+		})
+	}
+}

--- a/internal/middleware/http/request_test.go
+++ b/internal/middleware/http/request_test.go
@@ -1,4 +1,4 @@
-package custom
+package middleware
 
 import (
 	"bytes"

--- a/internal/middleware/middlewares.go
+++ b/internal/middleware/middlewares.go
@@ -14,7 +14,6 @@ func Middleware(r *chi.Mux) {
 
 func AddBaseMiddlewares(r *chi.Mux) {
 	r.Use(middleware.RealIP)
-	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 }
 

--- a/internal/middleware/middlewares.go
+++ b/internal/middleware/middlewares.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	compress "github.com/GlebRadaev/shlink/internal/middleware/compress"
 	http "github.com/GlebRadaev/shlink/internal/middleware/http"
 
 	"github.com/go-chi/chi/v5"
@@ -19,4 +20,5 @@ func AddBaseMiddlewares(r *chi.Mux) {
 
 func AddAdvancedMiddlewares(r *chi.Mux) {
 	r.Use(http.RequestMiddleware)
+	r.Use(compress.CompressMiddleware)
 }

--- a/internal/middleware/middlewares_test.go
+++ b/internal/middleware/middlewares_test.go
@@ -1,0 +1,54 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GlebRadaev/shlink/internal/middleware"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware(t *testing.T) {
+	r := chi.NewMux()
+	middleware.Middleware(r)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		realIP := r.Header.Get("X-Forwarded-For")
+		w.Header().Set("X-Real-IP", realIP)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "192.0.2.1")
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+	res := rec.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode, "unexpected status code")
+	body := rec.Body.String()
+	assert.Equal(t, "OK", body, "unexpected response body")
+	assert.Equal(t, "192.0.2.1", res.Header.Get("X-Real-IP"), "unexpected real IP")
+
+	t.Run("recoverer middleware", func(t *testing.T) {
+		r.Get("/panic", func(w http.ResponseWriter, r *http.Request) {
+			panic("test panic")
+		})
+		req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+		rec := httptest.NewRecorder()
+
+		r.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code, "unexpected status code on panic")
+	})
+}


### PR DESCRIPTION
- Added middleware to handle Content-Encoding: gzip for requests.
- Implemented response compression based on Accept-Encoding: gzip header.
- Limited compression to application/json and 'text/html' types.
- Integrated new middleware in AddAdvancedMiddlewares function.
- Removed unnecessary Content-Type validation in the URL handler.
- Renamed package custom to 'middleware' for better consistency